### PR TITLE
WriteOIIO: do not add "Color." to the channel names of the color plane

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,9 +106,9 @@ install:
 # see https://github.com/PixarAnimationStudios/USD/blob/master/.travis.yml
   - sudo apt-get install libopenjp2-7-dev libtiff-dev libjpeg-dev libpng-dev libraw-dev libboost-filesystem-dev libboost-regex-dev libboost-thread-dev libboost-system-dev libwebp-dev libfreetype6-dev libssl-dev
   - if [ ! -d "$HOME/oiio/lib" ]; then
-      wget https://github.com/OpenImageIO/oiio/archive/Release-2.1.10.0.tar.gz -O /tmp/oiio.tgz;
+      wget https://github.com/OpenImageIO/oiio/archive/Release-2.2.12.0.tar.gz -O /tmp/oiio.tgz;
       tar -xvzf /tmp/oiio.tgz -C $HOME;
-      pushd $HOME/oiio-Release-2.1.10.0;
+      pushd $HOME/oiio-Release-2.2.12.0;
       mkdir _build && cd _build;
       cmake -DCMAKE_INSTALL_PREFIX=$HOME/oiio -DILMBASE_ROOT_DIR=$HOME/openexr -DOPENEXR_ROOT_DIR=$HOME/openexr -DOCIO_HOME=$HOME/ocio -DUSE_QT=OFF -DUSE_PYTHON=OFF -DUSE_PYTHON3=OFF -DUSE_FIELD3D=OFF -DUSE_FFMPEG=OFF -DUSE_OPENJPEG=ON -DUSE_OCIO=ON -DUSE_OPENCV=OFF -DUSE_OPENSSL=OFF -DUSE_FREETYPE=ON -DUSE_GIF=OFF -DUSE_PTEX=OFF -DUSE_LIBRAW=ON -DOIIO_BUILD_TESTS=OFF -DOIIO_BUILD_TOOLS=OFF -DSTOP_ON_WARNING:BOOL=OFF ..;
       make $MAKEFLAGSPARALLEL && make install;

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -646,7 +646,8 @@ getDefaultBitDepth(const string& filepath,
     if (bitDepth != eTuttlePluginBitDepthAuto) {
         return bitDepth;
     }
-    string format = Strutil::lower( Filesystem::extension(filepath) );
+    string format = Filesystem::extension(filepath);
+    Strutil::to_lower(format);
     if ( (format == ".exr") ) {
         return eTuttlePluginBitDepth16f; // 16f is the most commonly used bit depth in the EXR world
     } else if ( (format == ".hdr") || (format == ".rgbe") || (format == ".pfm") ) {

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -1185,7 +1185,7 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
                 MultiPlane::ImagePlaneDesc::mapOFXComponentsTypeStringToPlanes(rawComponents, &plane, &pairedPlane);
 
                 std::vector<std::string> planeChannels = plane.getChannels();
-                if ( plane.getNumComponents() > 0 ) {
+                if ( plane.getNumComponents() > 0 && *it != kFnOfxImagePlaneColour) {
 
                     for (std::size_t i = 0; i < planeChannels.size(); ++i) {
                         planeChannels[i] = plane.getPlaneLabel() + "." + planeChannels[i];
@@ -1247,7 +1247,7 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
 
                 std::vector<std::string> planeChannels = plane.getChannels();
 
-                if ( plane.getNumComponents() > 0 ) {
+                if ( plane.getNumComponents() > 0 && *it != kFnOfxImagePlaneColour) {
                     for (std::size_t i = 0; i < planeChannels.size(); ++i) {
                         planeChannels[i] = plane.getPlaneLabel() + "." + planeChannels[i];
                     }
@@ -1303,8 +1303,10 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
 
 
                 ImageSpec partSpec = spec;
-                for (std::size_t i = 0; i < planeChannels.size(); ++i) {
-                    planeChannels[i] = plane.getPlaneLabel() + "." + planeChannels[i];
+                if ( plane.getNumComponents() > 0 && *it != kFnOfxImagePlaneColour) {
+                    for (std::size_t i = 0; i < planeChannels.size(); ++i) {
+                        planeChannels[i] = plane.getPlaneLabel() + "." + planeChannels[i];
+                    }
                 }
 
 

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -646,18 +646,22 @@ getDefaultBitDepth(const string& filepath,
     if (bitDepth != eTuttlePluginBitDepthAuto) {
         return bitDepth;
     }
-    string format = Filesystem::extension (filepath);
-    if ( (format.find("exr") != string::npos) ) {
+    string format = Strutil::lower( Filesystem::extension(filepath) );
+    if ( (format == ".exr") ) {
         return eTuttlePluginBitDepth16f; // 16f is the most commonly used bit depth in the EXR world
-    } else if ( (format.find("hdr") != string::npos) || (format.find("rgbe") != string::npos) ) {
+    } else if ( (format == ".hdr") || (format == ".rgbe") || (format == ".pfm") ) {
         return eTuttlePluginBitDepth32f;
-    } else if ( (format.find("jpg") != string::npos) || (format.find("jpeg") != string::npos) ||
-                ( format.find("bmp") != string::npos) || ( format.find("dds") != string::npos) ||
-                ( format.find("ico") != string::npos) || ( format.find("jfi") != string::npos) ||
-                ( format.find("pgm") != string::npos) || ( format.find("pnm") != string::npos) ||
-                ( format.find("ppm") != string::npos) || ( format.find("pbm") != string::npos) ||
-                ( format.find("pic") != string::npos) || ( format.find("tga") != string::npos) ||
-                ( format.find("png") != string::npos) ) {
+    } else if ( (format == ".jpg") || ( format == ".jpe") ||
+               ( format == ".jpeg") || ( format == ".jif") ||
+               ( format == ".jfif") || ( format == ".jfi") ||
+               ( format == ".bmp") ||
+               ( format == ".dds") ||
+               ( format == ".ico") ||
+               ( format == ".pgm") || ( format == ".pnm") ||
+               ( format == ".ppm") || ( format == ".pbm") ||
+               ( format == ".pic") ||
+               ( format == ".tga") || ( format == ".tpic") ||
+               ( format == ".png") ) {
         return eTuttlePluginBitDepth8;
     } else {
         //cin, dpx, fits, heic, heif, j2k, j2c, jp2, jpe, sgi, tif, tiff, tpic, webp

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -1219,16 +1219,14 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
                 }
             }
         }     //  for (std::size_t v = 0; v < viewsToRender.size(); ++v) {
-        if (channels.size() == 4) {
+        if ( channels.size() == 4 && (channels[3] == "A" || channels[3] =="alpha") ) {
             partSpec.alpha_channel = 3;
+        } else if ( channels.size() == 1 && (channels[0] == "A" || channels[0] =="alpha") ) {
+            // Alpha component only
+            partSpec.alpha_channel = 0;
         } else {
-            if (channels.size() == 1) {
-                ///Alpha component only
-                partSpec.alpha_channel = 0;
-            } else {
-                ///no alpha
-                partSpec.alpha_channel = -1;
-            }
+            // no alpha
+            partSpec.alpha_channel = -1;
         }
 
         partSpec.nchannels = channels.size();
@@ -1279,16 +1277,14 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
                     }
                 }
             }
-            if (channels.size() == 4) {
+            if ( channels.size() == 4 && (channels[3] == "A" || channels[3] =="alpha") ) {
                 partSpec.alpha_channel = 3;
+            } else if ( channels.size() == 1 && (channels[0] == "A" || channels[0] =="alpha") ) {
+                // Alpha component only
+                partSpec.alpha_channel = 0;
             } else {
-                if (channels.size() == 1) {
-                    ///Alpha component only
-                    partSpec.alpha_channel = 0;
-                } else {
-                    ///no alpha
-                    partSpec.alpha_channel = -1;
-                }
+                // no alpha
+                partSpec.alpha_channel = -1;
             }
 
             partSpec.nchannels = channels.size();
@@ -1340,16 +1336,14 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
                     }
                 }
 
-                if (channels.size() == 4) {
+                if ( channels.size() == 4 && (channels[3] == "A" || channels[3] =="alpha") ) {
                     partSpec.alpha_channel = 3;
+                } else if ( channels.size() == 1 && (channels[0] == "A" || channels[0] =="alpha") ) {
+                    // Alpha component only
+                    partSpec.alpha_channel = 0;
                 } else {
-                    if ( plane.getNumComponents() > 0 && ( channels.size() == 1) ) {
-                        ///Alpha component only
-                        partSpec.alpha_channel = 0;
-                    } else {
-                        ///no alpha
-                        partSpec.alpha_channel = -1;
-                    }
+                    // no alpha
+                    partSpec.alpha_channel = -1;
                 }
 
                 partSpec.nchannels = channels.size();


### PR DESCRIPTION
This resulted in color EXR with channel names:
channels (type chlist):
    Color.A, 16-bit floating-point, sampling 1 1
    Color.B, 16-bit floating-point, sampling 1 1
    Color.G, 16-bit floating-point, sampling 1 1
    Color.R, 16-bit floating-point, sampling 1 1

instead of the standard ones:
channels (type chlist):
    A, 16-bit floating-point, sampling 1 1
    B, 16-bit floating-point, sampling 1 1
    G, 16-bit floating-point, sampling 1 1
    R, 16-bit floating-point, sampling 1 1