### PR TITLE
GenericWriter: do not unpremult/premult before/after colorspace change.

### DIFF
--- a/EXR/WriteEXR.cpp
+++ b/EXR/WriteEXR.cpp
@@ -151,6 +151,12 @@ private:
     virtual PreMultiplicationEnum getExpectedInputPremultiplication() const OVERRIDE FINAL { return eImagePreMultiplied; }
 
     virtual void onOutputFileChanged(const string& newFile, bool setColorSpace) OVERRIDE FINAL;
+
+    /**
+     * @brief Does the given filename support alpha channel.
+     **/
+    virtual bool supportsAlpha(const std::string&) const OVERRIDE FINAL { return kSupportsRGBA; }
+
     ChoiceParam* _compression;
     ChoiceParam* _bitDepth;
 };

--- a/FFmpeg/WriteFFmpeg.cpp
+++ b/FFmpeg/WriteFFmpeg.cpp
@@ -1048,6 +1048,11 @@ private:
         updatePixelFormat();
     }
 
+    /**
+     * @brief Does the given filename support alpha channel.
+     **/
+    virtual bool supportsAlpha(const std::string&) const OVERRIDE FINAL;
+
     /** @brief the effect is about to be actively edited by a user, called when the first user interface is opened on an instance */
     virtual void beginEdit(void) OVERRIDE FINAL;
     virtual void beginEncode(const string& filename, const OfxRectI& rodPixel, float pixelAspectRatio, const BeginSequenceRenderArguments& args) OVERRIDE FINAL;
@@ -4836,6 +4841,13 @@ WriteFFmpegPlugin::onOutputFileChanged(const string &filename,
     updateVisibility();
 } // WriteFFmpegPlugin::onOutputFileChanged
 
+bool
+WriteFFmpegPlugin::supportsAlpha(const std::string&) const
+{
+    string pf;
+    _infoPixelFormat->getValue(pf);
+    return kSupportsRGBA && (pf.find('A') != string::npos);
+}
 
 static string
 ffmpeg_versions()

--- a/IOSupport/GenericWriter.cpp
+++ b/IOSupport/GenericWriter.cpp
@@ -607,9 +607,15 @@ GenericWriterPlugin::fetchPlaneConvertAndCopy(const string& plane,
                 unPremultPixelData(renderWindow, renderScale, srcPixelData, *bounds, srcMappedComponents, srcMappedComponentsCount
                                    , bitDepth, srcRowBytes, tmpPixelData, renderWindow, srcMappedComponents, srcMappedComponentsCount, bitDepth, tmpRowBytes);
 #             else
-                copyPixels(*this, renderWindowClipped, renderScale,
-                           srcPixelData, *bounds, srcMappedComponents, srcMappedComponentsCount, bitDepth, srcRowBytes,
-                           tmpPixelData, renderWindow, srcMappedComponents, srcMappedComponentsCount, bitDepth, tmpRowBytes);
+                if (pluginExpectedPremult == eImageUnPreMultiplied) {
+                    // unpremult before colorspace conversion, only if the plugin expects unpremult data (eg WritePNG)
+                    unPremultPixelData(renderWindow, renderScale, srcPixelData, *bounds, srcMappedComponents, srcMappedComponentsCount
+                                       , bitDepth, srcRowBytes, tmpPixelData, renderWindow, srcMappedComponents, srcMappedComponentsCount, bitDepth, tmpRowBytes);
+                } else {
+                    copyPixels(*this, renderWindowClipped, renderScale,
+                               srcPixelData, *bounds, srcMappedComponents, srcMappedComponentsCount, bitDepth, srcRowBytes,
+                               tmpPixelData, renderWindow, srcMappedComponents, srcMappedComponentsCount, bitDepth, tmpRowBytes);
+                }
 #             endif
             }
 #         ifdef OFX_IO_USING_OCIO

--- a/IOSupport/GenericWriter.h
+++ b/IOSupport/GenericWriter.h
@@ -331,6 +331,7 @@ public:
                                   const bool doAnyPacking,
                                   const bool packingContiguous,
                                   const std::vector<int>& packingMapping,
+                                  const bool alphaOK,
                                   InputImagesHolder* srcImgsHolder,
                                   OfxRectI* bounds,
                                   OFX::ImageMemory** tmpMem,
@@ -358,6 +359,11 @@ public:
     virtual void clearAnyCache() {}
 
     void getOutputRoD(OfxTime time, int view, OfxRectD* rod, double* par);
+
+    /**
+     * @brief Does the given filename support alpha channel.
+     **/
+    virtual bool supportsAlpha(const std::string& filename) const = 0;
 
 protected:
 

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -289,6 +289,12 @@ private:
     virtual LayerViewsPartsEnum getPartsSplittingPreference() const OVERRIDE FINAL;
     virtual int getViewToRender() const OVERRIDE FINAL;
     virtual void onOutputFileChanged(const string& filename, bool setColorSpace) OVERRIDE FINAL;
+
+    /**
+     * @brief Does the given filename support alpha channel.
+     **/
+    virtual bool supportsAlpha(const std::string&) const OVERRIDE FINAL;
+
     virtual void encode(const string& filename,
                         const OfxTime time,
                         const string& viewName,
@@ -783,6 +789,18 @@ WriteOIIOPlugin::onOutputFileChanged(const string &filename,
 
     refreshParamsVisibility(filename);
 } // WriteOIIOPlugin::onOutputFileChanged
+
+
+/**
+ * @brief Does the given filename support alpha channel.
+ **/
+bool
+WriteOIIOPlugin::supportsAlpha(const std::string& filename) const
+{
+    auto output = ImageOutput::create(filename);
+
+    return kSupportsRGBA && output->supports("alpha");
+}
 
 void
 WriteOIIOPlugin::refreshParamsVisibility(const string& filename)

--- a/PFM/WritePFM.cpp
+++ b/PFM/WritePFM.cpp
@@ -92,6 +92,13 @@ private:
     virtual PreMultiplicationEnum getExpectedInputPremultiplication() const OVERRIDE FINAL { return eImageUnPreMultiplied; }
 
     virtual void onOutputFileChanged(const string& newFile, bool setColorSpace) OVERRIDE FINAL;
+
+
+    /**
+     * @brief Does the given filename support alpha channel.
+     **/
+    virtual bool supportsAlpha(const std::string&) const OVERRIDE FINAL { return kSupportsRGBA; }
+
 };
 
 WritePFMPlugin::WritePFMPlugin(OfxImageEffectHandle handle,

--- a/PNG/WritePNG.cpp
+++ b/PNG/WritePNG.cpp
@@ -375,6 +375,11 @@ private:
 
     virtual void changedParam(const InstanceChangedArgs &args, const string &paramName) OVERRIDE FINAL;
 
+    /**
+     * @brief Does the given filename support alpha channel.
+     **/
+    virtual bool supportsAlpha(const std::string&) const OVERRIDE FINAL { return kSupportsRGBA; }
+
     void openFile(const string& filename,
                   int nChannels,
                   png_structp* png,


### PR DESCRIPTION
```
            // We should NEVER premult in a nonlinear colorspace if the output format doesn't support
            // alpha. https://github.com/NatronGitHub/Natron/issues/582
            // If the output format doesn't support Alpha, we just do the OCIO colorspace conversion on
            // premultiplied values.
            // It corresponds to merging over solid black.
            // Note that linear OCIO colorspaces do not need the unpremult/premult operations at all,
            // and could go in the if (isOCIOIdentity) branch above, if we were able to figure out that
            // they are linear.
            //
            // The decision to unpremult/premult before/after OCIO conversion is done this way:
            // alphaOK | userPremult | pluginExpectedPremult | doUnpremultBeforeOCIO | doPremultAfterOCIO
            //   true  |      U      |            U          |           no          |         no
            //   true  |      U      |            P          |           no          |        yes
            //   true  |      P      |            U          |          yes          |         no
            //   true  |      P      |            P          |          yes          |        yes
            //  false  |      U      |            U          |           no          |         no
            //  false  |      U      |            P          |           no          |         NO
            //  false  |      P      |            U          |          yes          |         no
            //  false  |      P      |            P          |           NO          |         NO (2)
            // Note the last line: it says that when saving to a format that doesn't handle alpha (eg jpg),
            // users prefer just considering the image as opaque and dropping alpha before color conversion.

```
fixes https://github.com/NatronGitHub/Natron/issues/582
see also https://github.com/OpenImageIO/oiio/issues/2887