### PR TITLE
Makefile.master: find OIIO using pkg-config

### DIFF
--- a/Makefile.master
+++ b/Makefile.master
@@ -35,8 +35,8 @@ FFMPEG_CXXFLAGS += -DOFX_IO_MT_FFMPEG
 
 # OpenImageIO
 OIIO_HOME ?= /usr
-OIIO_CXXFLAGS = $(OCIO_CXXFLAGS) -I$(OIIO_HOME)/include $(OPENEXR_CFLAGS) -DOFX_IO_USING_LIBRAW `pkg-config --cflags libraw_r libwebp libtiff-4 libopenjp2 libpng`
-OIIO_LINKFLAGS = $(OCIO_LINKFLAGS) -L$(OIIO_HOME)/lib -lOpenImageIO $(OPENEXR_LINKFLAGS) `pkg-config --libs libraw_r libwebp libtiff-4 libopenjp2 libpng`
+OIIO_CXXFLAGS = $(OCIO_CXXFLAGS) $(OPENEXR_CFLAGS) -DOFX_IO_USING_LIBRAW `pkg-config --cflags libraw_r libwebp libtiff-4 libopenjp2 libpng OpenImageIO`
+OIIO_LINKFLAGS = $(OCIO_LINKFLAGS) $(OPENEXR_LINKFLAGS) `pkg-config --libs libraw_r libwebp libtiff-4 libopenjp2 libpng OpenImageIO`
 ifeq ($(OS),Linux)
 # libraw_r may be in a separate directory for licence reasons (eg in the Natron SDK)
 OIIO_LINKFLAGS += -Wl,-rpath,$(OIIO_HOME)/lib -Wl,-rpath,`pkg-config --variable=libdir libraw_r`


### PR DESCRIPTION
Use pkg-config to find OIIO flags. Only tested on Windows.