### PR TITLE
Link IO with GLEW for OCIOv2 glsl

### DIFF
--- a/Makefile.master
+++ b/Makefile.master
@@ -18,7 +18,7 @@ ifeq ($(OS),Linux)
 OCIO_LINKFLAGS += -Wl,-rpath,`pkg-config --variable=libdir OpenColorIO`
 endif
 ifeq ($(shell pkg-config --modversion OpenColorIO | sed -e 's/\..*//'),2)
-OCIO_OPENGL_LINKFLAGS += -lOpenColorIOoglapphelpers
+OCIO_OPENGL_LINKFLAGS += -lOpenColorIOoglapphelpers `pkg-config --libs glew`
 endif
 
 # OpenEXR


### PR DESCRIPTION
Had issues while loading IO.ofx because GLEW is a [dependency of OCIOoglapphelpers](https://github.com/AcademySoftwareFoundation/OpenColorIO/blob/v2.0.2/src/libutils/oglapphelpers/glsl.cpp#L12-L16) and it reported the libGLEW missing symbols.
