### PR TITLE
Remove deprecated usages of the FFmpeg API

### DIFF
--- a/FFmpeg/FFmpegFile.cpp
+++ b/FFmpeg/FFmpegFile.cpp
@@ -517,15 +517,15 @@ FFmpegFile::getStreamStartTime(Stream & stream)
 
             // Read frames until we get one for the video stream that contains a valid PTS.
             while (av_read_frame(_context, avPacket.pkt()) >= 0) {
-                if (avPacket.pkt()->stream_index != stream._idx) {
+                if (avPacket->stream_index != stream._idx) {
                     continue;
                 }
                 // Packet read for video stream. Get its PTS.
-                startPTS = avPacket.pkt()->pts;
-                startDTS = avPacket.pkt()->dts;
+                startPTS = avPacket->pts;
+                startDTS = avPacket->dts;
 
                 // Loop will continue if the current packet doesn't end after 0
-                if (startPTS + avPacket.pkt()->duration > 0) {
+                if (startPTS + avPacket->duration > 0) {
                     break;
                 }
             }
@@ -554,7 +554,7 @@ FFmpegFile::getStreamStartTime(Stream & stream)
     // frame timestamp is going to match the packet which starts just before 0 and ends after 0 if that exists. Otherwise
     // it will be 0.
     // For more information please have a look at TP 162519
-    const bool isStartPTSValid = (startPTS + avPacket.pkt()->duration > 0);
+    const bool isStartPTSValid = (startPTS + avPacket->duration > 0);
     if (!isStartPTSValid) {
 #if TRACE_FILE_OPEN
         std::cout << "        Not found by searching frames, assuming ";
@@ -675,8 +675,8 @@ FFmpegFile::getStreamFrames(Stream & stream)
         // https://foundry.tpondemand.com/entity/162892
 
         while (av_read_frame(_context, avPacket.pkt()) >= 0) {
-            if (avPacket.pkt()->stream_index == stream._idx && avPacket.pkt()->pts != int64_t(AV_NOPTS_VALUE) && avPacket.pkt()->pts > maxPts)
-                maxPts = avPacket.pkt()->pts;
+            if (avPacket->stream_index == stream._idx && avPacket->pts != int64_t(AV_NOPTS_VALUE) && avPacket->pts > maxPts)
+                maxPts = avPacket->pts;
         }
 #if TRACE_FILE_OPEN
         std::cout << "          Start PTS=" << stream._startPTS << ", Max PTS found=" << maxPts << std::endl;
@@ -1438,7 +1438,7 @@ bool FFmpegFile::demuxAndDecode(AVFrame* avFrameOut, int64_t frame)
     // Begin reading from the newly seeked position
     while ((res = av_read_frame(_context, avPacket.pkt())) >= 0) {
 
-        if (avPacket.pkt()->stream_index == stream->_idx) {
+        if (avPacket->stream_index == stream->_idx) {
 
             if ((res = mov64_av_decode(stream->_codecContext, avFrameDecodeDst, &frameDecoded, avPacket.pkt())) < 0) {
                 setInternalError(res, "FFmpeg Reader Failed to decode packet: ");

--- a/FFmpeg/FFmpegFile.h
+++ b/FFmpeg/FFmpegFile.h
@@ -102,36 +102,16 @@ class ImageEffect;
 class MyAVPacket
 {
 public:
-    MyAVPacket(AVPacket *avpkt = nullptr)
+    MyAVPacket()
     {
-        InitPacket(avpkt);
+        _pkt = av_packet_alloc();
     }
     ~MyAVPacket()
     {
-        FreePacket();
+        av_packet_free(&_pkt);
     }
 
-public:
-    void InitPacket(AVPacket *avpkt)
-    {
-        _internalPkt = avpkt == nullptr;
-        if (_internalPkt) {
-            avpkt = av_packet_alloc();
-        }
-        _pkt = avpkt;
-    }
-    void FreePacket()
-    {
-        if (_internalPkt) {
-            av_packet_free(&_pkt);
-        } else {
-            if (_pkt != nullptr)
-                av_packet_unref(_pkt);
-            _pkt = nullptr;
-        }
-    }
-
-    inline AVPacket* pkt() const {
+    AVPacket* pkt() const {
         return _pkt;
     }
 
@@ -140,7 +120,6 @@ public:
     }
 private:
     AVPacket *_pkt;
-    bool _internalPkt;
 };
 
 class FFmpegFile

--- a/FFmpeg/FFmpegFile.h
+++ b/FFmpeg/FFmpegFile.h
@@ -289,12 +289,12 @@ private:
         }
     };
 
-    struct MyAVPacket : public AVPacket
+    struct MyAVPacket
     {
     public:
-        MyAVPacket()
+        MyAVPacket(AVPacket *avpkt)
         {
-            InitPacket();
+            InitPacket(avpkt);
         }
         ~MyAVPacket()
         {
@@ -302,17 +302,22 @@ private:
         }
 
     public:
-        void InitPacket()
+        void InitPacket(AVPacket *avpkt)
         {
-            data = nullptr;
-            size = 0;
-
-            av_init_packet(this);
+            _pkt = avpkt;
         }
         void FreePacket()
         {
-            av_packet_unref(this); //av_free_packet(this);
+            if (_pkt != nullptr)
+                av_packet_unref(_pkt); //av_free_packet(this);
+            _pkt = nullptr;
         }
+
+        inline AVPacket* pkt() const {
+            return _pkt;
+        }
+    private:
+        AVPacket *_pkt;
     };
 
     std::string _filename;
@@ -330,7 +335,7 @@ private:
     // reader error state
     std::string _errorMsg;  // internal decoding error string
     bool _invalidState;     // true if the reader is in an invalid state
-    MyAVPacket _avPacket;
+    AVPacket *_pkt;
 
 #ifdef OFX_IO_MT_FFMPEG
     // internal lock for multithread access

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ and change the include/lib paths in the visual studio project.
 
 I can only advice you download the pre-built binaries from [Zeranoe](http://ffmpeg.zeranoe.com/builds/).
 You will need to download the Shared to have the dlls and the Dev to have the .lib files allowing you to link with the dlls.
-Note that on this website you can only get shared versions of the ffmpeg libraries.
+Note that on this website you can only get shared versions of the ffmpeg libraries. Only version 4.0 and onwards are supported.
 
 ### Boost
 


### PR DESCRIPTION
Compiling with newer FFmpeg versions reports lots of deprecation warnings (`-Wdeprecated`) regarding dec&enc methods and packet creation/allocation. This PR updates dec&enc to the much newer `avcodec_send_<packet/frame>` plus `avcodec_receive_<frame/packet>` API and uses dynamic allocation for `AVPacket`s.

Tested via decoding and encoding different footage in Natron.
