### PR TITLE
Permit compilation with FFmpeg 5.0

### DIFF
--- a/FFmpeg/FFmpegFile.cpp
+++ b/FFmpeg/FFmpegFile.cpp
@@ -848,7 +848,7 @@ FFmpegFile::FFmpegFile(const string & filename)
         }
 
         // find the codec
-        AVCodec* videoCodec = avcodec_find_decoder(codecCtx->codec_id);
+        const AVCodec* videoCodec = avcodec_find_decoder(codecCtx->codec_id);
         if (videoCodec == nullptr) {
 #if TRACE_FILE_OPEN
             std::cout << "Decoder not found, skipping..." << std::endl;

--- a/FFmpeg/FFmpegFile.h
+++ b/FFmpeg/FFmpegFile.h
@@ -139,7 +139,7 @@ private:
         int _idx;                      // stream index
         AVStream* _avstream;           // video stream
         AVCodecContext* _codecContext; // video codec context
-        AVCodec* _videoCodec;
+        const AVCodec* _videoCodec;
         AVFrame* _avFrame;             // decoding frame
         AVFrame* _avIntermediateFrame; // decode into this if an image conversion is required
         SwsContext* _convertCtx;


### PR DESCRIPTION
Fixes #22. FFmpeg 4.4 could still be supported, though you might have to pass some configurations, alternatively you should modify some Make or CMake files.
