### PR TITLE
Make OCIO SupportsOpenGL and SupportsTiles logic more consistent

### DIFF
--- a/OCIO/Makefile
+++ b/OCIO/Makefile
@@ -1,4 +1,4 @@
-PLUGINOBJECTS = ofxsThreadSuite.o tinythread.o OCIOCDLTransform.o OCIOColorSpace.o OCIODisplay.o OCIOFileTransform.o OCIOLogConvert.o OCIOLookTransform.o GenericOCIO.o $(OCIO_OPENGL_OBJS)
+PLUGINOBJECTS = ofxsThreadSuite.o tinythread.o OCIOCDLTransform.o OCIOColorSpace.o OCIODisplay.o OCIOFileTransform.o OCIOLogConvert.o OCIOLookTransform.o OCIOPluginBase.o GenericOCIO.o $(OCIO_OPENGL_OBJS)
 OCIO_OPENGL_OBJS = GenericOCIOOpenGL.o glsl.o glad.o ofxsOGLUtilities.o
 PLUGINNAME = OCIO
 

--- a/OCIO/OCIOCDLTransform.cpp
+++ b/OCIO/OCIOCDLTransform.cpp
@@ -62,7 +62,7 @@ OFXS_NAMESPACE_ANONYMOUS_ENTER
 
 #define kPluginIdentifier "fr.inria.openfx.OCIOCDLTransform"
 #define kPluginVersionMajor 1 // Incrementing this number means that you have broken backwards compatibility of the plug-in.
-#define kPluginVersionMinor 0 // Increment this when you have fixed a bug or made it faster.
+#define kPluginVersionMinor 1 // Increment this when you have fixed a bug or made it faster.
 
 #define kSupportsTiles 1
 #define kSupportsMultiResolution 1
@@ -433,14 +433,7 @@ OCIOCDLTransformPlugin::OCIOCDLTransformPlugin(OfxImageEffectHandle handle)
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
     _enableGPU = fetchBooleanParam(kParamEnableGPU);
     assert(_enableGPU);
-    const ImageEffectHostDescription& gHostDescription = *getImageEffectHostDescription();
-    if (!gHostDescription.supportsOpenGLRender) {
-        _enableGPU->setEnabled(false);
-    }
-    // GPU rendering is wrong when (un)premult is checked
-    bool premult = _premult->getValue();
-    _enableGPU->setEnabled(!premult);
-    setSupportsOpenGLRender(!premult && _enableGPU->getValue());
+    setSupportsOpenGLAndTileInfo(_premult, _enableGPU, nullptr);
 #endif
 
     bool readFromFile;
@@ -1258,12 +1251,7 @@ OCIOCDLTransformPlugin::changedParam(const InstanceChangedArgs& args,
         _export->setValue(kParamExportDefault);
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
     } else if (paramName == kParamEnableGPU || paramName == kParamPremult) {
-        // GPU rendering is wrong when (un)premult is checked
-        bool premult = _premult->getValueAtTime(args.time);
-        _enableGPU->setEnabled(!premult);
-        bool supportsGL = !premult && _enableGPU->getValueAtTime(args.time);
-        setSupportsOpenGLRender(supportsGL);
-        setSupportsTiles(!supportsGL);
+        setSupportsOpenGLAndTileInfo(_premult, _enableGPU, &args.time);
 #endif
     }
 } // OCIOCDLTransformPlugin::changedParam

--- a/OCIO/OCIOCDLTransform.cpp
+++ b/OCIO/OCIOCDLTransform.cpp
@@ -405,7 +405,7 @@ OCIOCDLTransformPlugin::OCIOCDLTransformPlugin(OfxImageEffectHandle handle)
     assert(_mix && _maskInvert);
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    setSupportsOpenGLAndTileInfo(nullptr);
+    setSupportsOpenGLAndTileInfo();
 #endif
 
     bool readFromFile;
@@ -1221,7 +1221,7 @@ OCIOCDLTransformPlugin::changedParam(const InstanceChangedArgs& args,
         _export->setValue(kParamExportDefault);
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
     } else if (paramEffectsOpenGLAndTileSupport(paramName) || paramName == kParamPremult) {
-        setSupportsOpenGLAndTileInfo(&args.time);
+        setSupportsOpenGLAndTileInfoAtTime(args.time);
 #endif
     }
 } // OCIOCDLTransformPlugin::changedParam

--- a/OCIO/OCIOCDLTransform.cpp
+++ b/OCIO/OCIOCDLTransform.cpp
@@ -36,6 +36,7 @@
 #include "ofxsThreadSuite.h"
 
 #include "GenericOCIO.h"
+#include "OCIOPluginBase.h"
 
 namespace OCIO = OCIO_NAMESPACE;
 
@@ -146,7 +147,7 @@ OFXS_NAMESPACE_ANONYMOUS_ENTER
 static bool gHostIsNatron = false; // TODO: generate a CCCId choice param kParamCCCIDChoice from available IDs
 
 class OCIOCDLTransformPlugin
-    : public ImageEffect {
+    : public OCIOPluginBase {
 public:
     OCIOCDLTransformPlugin(OfxImageEffectHandle handle);
 
@@ -368,7 +369,7 @@ private:
 };
 
 OCIOCDLTransformPlugin::OCIOCDLTransformPlugin(OfxImageEffectHandle handle)
-    : ImageEffect(handle)
+    : OCIOPluginBase(handle)
     , _dstClip(NULL)
     , _srcClip(NULL)
     , _maskClip(NULL)

--- a/OCIO/OCIOColorSpace.cpp
+++ b/OCIO/OCIOColorSpace.cpp
@@ -282,7 +282,7 @@ OCIOColorSpacePlugin::OCIOColorSpacePlugin(OfxImageEffectHandle handle)
     assert(_mix && _maskInvert);
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    setSupportsOpenGLAndTileInfo(nullptr);
+    setSupportsOpenGLAndTileInfo();
 #endif
 }
 
@@ -749,7 +749,7 @@ OCIOColorSpacePlugin::changedParam(const InstanceChangedArgs& args,
     clearPersistentMessage();
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
     if (paramEffectsOpenGLAndTileSupport(paramName) || paramName == kParamPremult) {
-        setSupportsOpenGLAndTileInfo(&args.time);
+        setSupportsOpenGLAndTileInfoAtTime(args.time);
         return;
     }
 #endif

--- a/OCIO/OCIOColorSpace.cpp
+++ b/OCIO/OCIOColorSpace.cpp
@@ -24,7 +24,7 @@
 
 #ifdef OFX_IO_USING_OCIO
 
-//#include <iostream>
+// #include <iostream>
 #include <memory>
 #ifdef DEBUG
 #include <cstdio> // printf
@@ -33,6 +33,7 @@
 #include "GenericOCIO.h"
 
 #include "IOUtility.h"
+#include "OCIOPluginBase.h"
 #include "ofxsCoords.h"
 #include "ofxsCopier.h"
 #include "ofxsMacros.h"
@@ -77,7 +78,7 @@ OFXS_NAMESPACE_ANONYMOUS_ENTER
 #endif
 
 class OCIOColorSpacePlugin
-    : public ImageEffect {
+    : public OCIOPluginBase {
 public:
     OCIOColorSpacePlugin(OfxImageEffectHandle handle);
 
@@ -278,7 +279,7 @@ private:
 };
 
 OCIOColorSpacePlugin::OCIOColorSpacePlugin(OfxImageEffectHandle handle)
-    : ImageEffect(handle)
+    : OCIOPluginBase(handle)
     , _dstClip(NULL)
     , _srcClip(NULL)
     , _maskClip(NULL)

--- a/OCIO/OCIODisplay.cpp
+++ b/OCIO/OCIODisplay.cpp
@@ -23,7 +23,7 @@
  */
 
 #ifdef OFX_IO_USING_OCIO
-//#include <iostream>
+// #include <iostream>
 #include <algorithm>
 #include <memory>
 #ifdef DEBUG
@@ -32,6 +32,7 @@
 
 #include "GenericOCIO.h"
 #include "IOUtility.h"
+#include "OCIOPluginBase.h"
 #include "ofxsCoords.h"
 #include "ofxsCopier.h"
 #include "ofxsMacros.h"
@@ -165,7 +166,7 @@ buildViewMenu(OCIO::ConstConfigRcPtr config,
 }
 
 class OCIODisplayPlugin
-    : public ImageEffect {
+    : public OCIOPluginBase {
 public:
     OCIODisplayPlugin(OfxImageEffectHandle handle);
 
@@ -378,7 +379,7 @@ private:
 };
 
 OCIODisplayPlugin::OCIODisplayPlugin(OfxImageEffectHandle handle)
-    : ImageEffect(handle)
+    : OCIOPluginBase(handle)
     , _dstClip(NULL)
     , _srcClip(NULL)
     , _display(NULL)

--- a/OCIO/OCIODisplay.cpp
+++ b/OCIO/OCIODisplay.cpp
@@ -392,7 +392,7 @@ OCIODisplayPlugin::OCIODisplayPlugin(OfxImageEffectHandle handle)
     _view = fetchStringParam(kParamView);
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    setSupportsOpenGLAndTileInfo(nullptr);
+    setSupportsOpenGLAndTileInfo();
 #endif
 
     if (gHostIsNatron) {
@@ -1133,7 +1133,7 @@ OCIODisplayPlugin::changedParam(const InstanceChangedArgs& args,
         }
 #ifdef OFX_SUPPORTS_OPENGLRENDER
     } else if (paramEffectsOpenGLAndTileSupport(paramName)) {
-        setSupportsOpenGLAndTileInfo(&args.time);
+        setSupportsOpenGLAndTileInfoAtTime(args.time);
 #endif
     } else {
         return _ocio->changedParam(args, paramName);

--- a/OCIO/OCIOFileTransform.cpp
+++ b/OCIO/OCIOFileTransform.cpp
@@ -24,7 +24,7 @@
 
 #ifdef OFX_IO_USING_OCIO
 
-//#include <stdio.h> // for snprintf & _snprintf
+// #include <stdio.h> // for snprintf & _snprintf
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 #include <windows.h>
 #if defined(_MSC_VER) && _MSC_VER < 1900
@@ -38,6 +38,7 @@
 
 #include "GenericOCIO.h"
 #include "IOUtility.h"
+#include "OCIOPluginBase.h"
 #include "ofxNatron.h"
 #include "ofxsCoords.h"
 #include "ofxsCopier.h"
@@ -124,7 +125,7 @@ OFXS_NAMESPACE_ANONYMOUS_ENTER
 static bool gHostIsNatron = false; // TODO: generate a CCCId choice param kParamCCCIDChoice from available IDs
 
 class OCIOFileTransformPlugin
-    : public ImageEffect {
+    : public OCIOPluginBase {
 public:
     OCIOFileTransformPlugin(OfxImageEffectHandle handle);
 
@@ -328,7 +329,7 @@ private:
 };
 
 OCIOFileTransformPlugin::OCIOFileTransformPlugin(OfxImageEffectHandle handle)
-    : ImageEffect(handle)
+    : OCIOPluginBase(handle)
     , _dstClip(NULL)
     , _srcClip(NULL)
     , _maskClip(NULL)

--- a/OCIO/OCIOFileTransform.cpp
+++ b/OCIO/OCIOFileTransform.cpp
@@ -344,7 +344,7 @@ OCIOFileTransformPlugin::OCIOFileTransformPlugin(OfxImageEffectHandle handle)
     _maskInvert = fetchBooleanParam(kParamMaskInvert);
     assert(_mix && _maskInvert);
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    setSupportsOpenGLAndTileInfo(nullptr);
+    setSupportsOpenGLAndTileInfo();
 #endif
 
     updateCCCId();
@@ -905,7 +905,7 @@ OCIOFileTransformPlugin::changedParam(const InstanceChangedArgs& args,
         OCIO::ClearAllCaches();
 #ifdef OFX_SUPPORTS_OPENGLRENDER
     } else if (paramEffectsOpenGLAndTileSupport(paramName) || paramName == kParamPremult) {
-        setSupportsOpenGLAndTileInfo(&args.time);
+        setSupportsOpenGLAndTileInfoAtTime(args.time);
 #endif
     }
 }

--- a/OCIO/OCIOFileTransform.cpp
+++ b/OCIO/OCIOFileTransform.cpp
@@ -105,23 +105,6 @@ OFXS_NAMESPACE_ANONYMOUS_ENTER
 #define kParamInterpolationOptionTetrahedral "Tetrahedral", "", "tetrahedral"
 #define kParamInterpolationOptionBest "Best", "", "best"
 
-#if defined(OFX_SUPPORTS_OPENGLRENDER)
-#define kParamEnableGPU "enableGPU"
-#define kParamEnableGPULabel "Enable GPU Render"
-#if OCIO_VERSION_HEX >= 0x02000000
-#define kParamEnableGPUHint_warn ""
-#else
-// OCIO1's GPU render is not accurate enough.
-// see https://github.com/imageworks/OpenColorIO/issues/394
-// and https://github.com/imageworks/OpenColorIO/issues/456
-#define kParamEnableGPUHint_warn "Note that GPU render is not as accurate as CPU render, so this should be enabled with care.\n"
-#endif
-#define kParamEnableGPUHint                                                                                                                                                              \
-    "Enable GPU-based OpenGL render (only available when \"(Un)premult\" is not checked).\n" kParamEnableGPUHint_warn                                                                    \
-    "If the checkbox is checked but is not enabled (i.e. it cannot be unchecked), GPU render can not be enabled or disabled from the plugin and is probably part of the host options.\n" \
-    "If the checkbox is not checked and is not enabled (i.e. it cannot be checked), GPU render is not available on this host."
-#endif
-
 static bool gHostIsNatron = false; // TODO: generate a CCCId choice param kParamCCCIDChoice from available IDs
 
 class OCIOFileTransformPlugin
@@ -323,7 +306,6 @@ private:
     int _procInterpolation;
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    BooleanParam* _enableGPU;
     OCIOOpenGLContextData* _openGLContextData; // (OpenGL-only) - the single openGL context, in case the host does not support kNatronOfxImageEffectPropOpenGLContextData
 #endif
 };
@@ -346,7 +328,6 @@ OCIOFileTransformPlugin::OCIOFileTransformPlugin(OfxImageEffectHandle handle)
     , _procDirection(-1)
     , _procInterpolation(-1)
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    , _enableGPU(NULL)
     , _openGLContextData(NULL)
 #endif
 {
@@ -370,9 +351,7 @@ OCIOFileTransformPlugin::OCIOFileTransformPlugin(OfxImageEffectHandle handle)
     _maskInvert = fetchBooleanParam(kParamMaskInvert);
     assert(_mix && _maskInvert);
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    _enableGPU = fetchBooleanParam(kParamEnableGPU);
-    assert(_enableGPU);
-    setSupportsOpenGLAndTileInfo(_premult, _enableGPU, nullptr);
+    setSupportsOpenGLAndTileInfo(_premult,nullptr);
 #endif
 
     updateCCCId();
@@ -934,8 +913,8 @@ OCIOFileTransformPlugin::changedParam(const InstanceChangedArgs& args,
         _version->setValue(_version->getValue() + 1); // invalidate the node cache
         OCIO::ClearAllCaches();
 #ifdef OFX_SUPPORTS_OPENGLRENDER
-    } else if (paramName == kParamEnableGPU || paramName == kParamPremult) {
-        setSupportsOpenGLAndTileInfo(_premult, _enableGPU, &args.time);
+    } else if (paramEffectsOpenGLAndTileSupport(paramName) || paramName == kParamPremult) {
+        setSupportsOpenGLAndTileInfo(_premult, &args.time);
 #endif
     }
 }
@@ -1105,29 +1084,7 @@ OCIOFileTransformPluginFactory::describeInContext(ImageEffectDescriptor& desc,
     }
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    {
-        BooleanParamDescriptor* param = desc.defineBooleanParam(kParamEnableGPU);
-        param->setLabel(kParamEnableGPULabel);
-        param->setHint(kParamEnableGPUHint);
-        const ImageEffectHostDescription& gHostDescription = *getImageEffectHostDescription();
-        // Resolve advertises OpenGL support in its host description, but never calls render with OpenGL enabled
-        if (gHostDescription.supportsOpenGLRender && (gHostDescription.hostName != "DaVinciResolveLite")) {
-            // OCIO's GPU render is not accurate enough.
-            // see https://github.com/imageworks/OpenColorIO/issues/394
-            param->setDefault(/*true*/ false);
-            if (gHostDescription.APIVersionMajor * 100 + gHostDescription.APIVersionMinor < 104) {
-                // Switching OpenGL render from the plugin was introduced in OFX 1.4
-                param->setEnabled(false);
-            }
-        } else {
-            param->setDefault(false);
-            param->setEnabled(false);
-        }
-
-        if (page) {
-            page->addChild(*param);
-        }
-    }
+    OCIOPluginBase::defineEnableGPUParam(desc, page);
 #endif
 
     ofxsPremultDescribeParams(desc, page);

--- a/OCIO/OCIOLogConvert.cpp
+++ b/OCIO/OCIOLogConvert.cpp
@@ -298,7 +298,7 @@ OCIOLogConvertPlugin::OCIOLogConvertPlugin(OfxImageEffectHandle handle)
     assert(_mix && _maskInvert);
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    setSupportsOpenGLAndTileInfo(nullptr);
+    setSupportsOpenGLAndTileInfo();
 #endif
 
     loadConfig(0.);
@@ -893,7 +893,7 @@ OCIOLogConvertPlugin::changedParam(const InstanceChangedArgs& args,
         sendMessage(Message::eMessageMessage, "", msg);
 #ifdef OFX_SUPPORTS_OPENGLRENDER
     } else if (paramEffectsOpenGLAndTileSupport(paramName) || paramName == kParamPremult) {
-        setSupportsOpenGLAndTileInfo(&args.time);
+        setSupportsOpenGLAndTileInfoAtTime(args.time);
 #endif
     }
 } // OCIOLogConvertPlugin::changedParam

--- a/OCIO/OCIOLogConvert.cpp
+++ b/OCIO/OCIOLogConvert.cpp
@@ -30,6 +30,7 @@
 #endif
 #include "GenericOCIO.h"
 #include "IOUtility.h"
+#include "OCIOPluginBase.h"
 #include "ofxNatron.h"
 #include "ofxsCoords.h"
 #include "ofxsCopier.h"
@@ -85,7 +86,7 @@ OFXS_NAMESPACE_ANONYMOUS_ENTER
 static bool gWasOCIOEnvVarFound = false;
 
 class OCIOLogConvertPlugin
-    : public ImageEffect {
+    : public OCIOPluginBase {
 public:
     OCIOLogConvertPlugin(OfxImageEffectHandle handle);
 
@@ -286,7 +287,7 @@ private:
 };
 
 OCIOLogConvertPlugin::OCIOLogConvertPlugin(OfxImageEffectHandle handle)
-    : ImageEffect(handle)
+    : OCIOPluginBase(handle)
     , _dstClip(NULL)
     , _srcClip(NULL)
     , _maskClip(NULL)

--- a/OCIO/OCIOLogConvert.cpp
+++ b/OCIO/OCIOLogConvert.cpp
@@ -66,23 +66,6 @@ OFXS_NAMESPACE_ANONYMOUS_ENTER
 #define kParamOperationOptionLogToLin "Log to Lin", "", "log2lin"
 #define kParamOperationOptionLinToLog "Lin to Log", "", "lin2log"
 
-#if defined(OFX_SUPPORTS_OPENGLRENDER)
-#define kParamEnableGPU "enableGPU"
-#define kParamEnableGPULabel "Enable GPU Render"
-#if OCIO_VERSION_HEX >= 0x02000000
-#define kParamEnableGPUHint_warn ""
-#else
-// OCIO1's GPU render is not accurate enough.
-// see https://github.com/imageworks/OpenColorIO/issues/394
-// and https://github.com/imageworks/OpenColorIO/issues/456
-#define kParamEnableGPUHint_warn "Note that GPU render is not as accurate as CPU render, so this should be enabled with care.\n"
-#endif
-#define kParamEnableGPUHint                                                                                                                                                              \
-    "Enable GPU-based OpenGL render (only available when \"(Un)premult\" is not checked).\n" kParamEnableGPUHint_warn                                                                    \
-    "If the checkbox is checked but is not enabled (i.e. it cannot be unchecked), GPU render can not be enabled or disabled from the plugin and is probably part of the host options.\n" \
-    "If the checkbox is not checked and is not enabled (i.e. it cannot be checked), GPU render is not available on this host."
-#endif
-
 static bool gWasOCIOEnvVarFound = false;
 
 class OCIOLogConvertPlugin
@@ -281,7 +264,6 @@ private:
     int _procMode;
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    BooleanParam* _enableGPU;
     OCIOOpenGLContextData* _openGLContextData; // (OpenGL-only) - the single openGL context, in case the host does not support kNatronOfxImageEffectPropOpenGLContextData
 #endif
 };
@@ -301,7 +283,6 @@ OCIOLogConvertPlugin::OCIOLogConvertPlugin(OfxImageEffectHandle handle)
     , _maskInvert(NULL)
     , _procMode(-1)
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    , _enableGPU(NULL)
     , _openGLContextData(NULL)
 #endif
 {
@@ -324,9 +305,7 @@ OCIOLogConvertPlugin::OCIOLogConvertPlugin(OfxImageEffectHandle handle)
     assert(_mix && _maskInvert);
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    _enableGPU = fetchBooleanParam(kParamEnableGPU);
-    assert(_enableGPU);
-    setSupportsOpenGLAndTileInfo(_premult, _enableGPU, nullptr);
+    setSupportsOpenGLAndTileInfo(_premult, nullptr);
 #endif
 
     loadConfig(0.);
@@ -922,8 +901,8 @@ OCIOLogConvertPlugin::changedParam(const InstanceChangedArgs& args,
         }
         sendMessage(Message::eMessageMessage, "", msg);
 #ifdef OFX_SUPPORTS_OPENGLRENDER
-    } else if (paramName == kParamEnableGPU || paramName == kParamPremult) {
-        setSupportsOpenGLAndTileInfo(_premult, _enableGPU, &args.time);
+    } else if (paramEffectsOpenGLAndTileSupport(paramName) || paramName == kParamPremult) {
+        setSupportsOpenGLAndTileInfo(_premult, &args.time);
 #endif
     }
 } // OCIOLogConvertPlugin::changedParam
@@ -1069,29 +1048,7 @@ OCIOLogConvertPluginFactory::describeInContext(ImageEffectDescriptor& desc,
     }
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    {
-        BooleanParamDescriptor* param = desc.defineBooleanParam(kParamEnableGPU);
-        param->setLabel(kParamEnableGPULabel);
-        param->setHint(kParamEnableGPUHint);
-        const ImageEffectHostDescription& gHostDescription = *getImageEffectHostDescription();
-        // Resolve advertises OpenGL support in its host description, but never calls render with OpenGL enabled
-        if (gHostDescription.supportsOpenGLRender && (gHostDescription.hostName != "DaVinciResolveLite")) {
-            // OCIO's GPU render is not accurate enough.
-            // see https://github.com/imageworks/OpenColorIO/issues/394
-            param->setDefault(/*true*/ false);
-            if (gHostDescription.APIVersionMajor * 100 + gHostDescription.APIVersionMinor < 104) {
-                // Switching OpenGL render from the plugin was introduced in OFX 1.4
-                param->setEnabled(false);
-            }
-        } else {
-            param->setDefault(false);
-            param->setEnabled(false);
-        }
-
-        if (page) {
-            page->addChild(*param);
-        }
-    }
+    OCIOPluginBase::defineEnableGPUParam(desc, page);
 #endif
 
     ofxsPremultDescribeParams(desc, page);

--- a/OCIO/OCIOLookTransform.cpp
+++ b/OCIO/OCIOLookTransform.cpp
@@ -101,23 +101,6 @@ using std::string;
 #define kParamDirectionOptionForward "Forward", "", "forward"
 #define kParamDirectionOptionInverse "Inverse", "", "inverse"
 
-#if defined(OFX_SUPPORTS_OPENGLRENDER)
-#define kParamEnableGPU "enableGPU"
-#define kParamEnableGPULabel "Enable GPU Render"
-#if OCIO_VERSION_HEX >= 0x02000000
-#define kParamEnableGPUHint_warn ""
-#else
-// OCIO1's GPU render is not accurate enough.
-// see https://github.com/imageworks/OpenColorIO/issues/394
-// and https://github.com/imageworks/OpenColorIO/issues/456
-#define kParamEnableGPUHint_warn "Note that GPU render is not as accurate as CPU render, so this should be enabled with care.\n"
-#endif
-#define kParamEnableGPUHint                                                                                                                                                              \
-    "Enable GPU-based OpenGL render (only available when \"(Un)premult\" is not checked).\n" kParamEnableGPUHint_warn                                                                    \
-    "If the checkbox is checked but is not enabled (i.e. it cannot be unchecked), GPU render can not be enabled or disabled from the plugin and is probably part of the host options.\n" \
-    "If the checkbox is not checked and is not enabled (i.e. it cannot be checked), GPU render is not available on this host."
-#endif
-
 namespace OCIO = OCIO_NAMESPACE;
 
 static bool gHostIsNatron = false;
@@ -324,7 +307,6 @@ private:
     DoubleParam* _mix;
     BooleanParam* _maskApply;
     BooleanParam* _maskInvert;
-    BooleanParam* _enableGPU;
 
     auto_ptr<GenericOCIO> _ocio;
 
@@ -355,7 +337,6 @@ OCIOLookTransformPlugin::OCIOLookTransformPlugin(OfxImageEffectHandle handle)
     , _mix(NULL)
     , _maskApply(NULL)
     , _maskInvert(NULL)
-    , _enableGPU(NULL)
     , _ocio(new GenericOCIO(this))
     , _procDirection(-1)
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
@@ -384,9 +365,7 @@ OCIOLookTransformPlugin::OCIOLookTransformPlugin(OfxImageEffectHandle handle)
     assert(_mix && _maskInvert);
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    _enableGPU = fetchBooleanParam(kParamEnableGPU);
-    assert(_enableGPU);
-    setSupportsOpenGLAndTileInfo(_premult, _enableGPU, nullptr);
+    setSupportsOpenGLAndTileInfo(_premult, nullptr);
 #endif
 
     bool singleLook = _singleLook->getValue();
@@ -976,8 +955,8 @@ OCIOLookTransformPlugin::changedParam(const InstanceChangedArgs& args,
         _lookCombination->setEnabled(!singleLook);
         _lookCombination->setEvaluateOnChange(!singleLook);
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    } else if (paramName == kParamEnableGPU || paramName == kParamPremult) {
-        setSupportsOpenGLAndTileInfo(_premult, _enableGPU, &args.time);
+    } else if (paramEffectsOpenGLAndTileSupport(paramName) || paramName == kParamPremult) {
+        setSupportsOpenGLAndTileInfo(_premult, &args.time);
 #endif
     } else {
         _ocio->changedParam(args, paramName);
@@ -1161,29 +1140,7 @@ OCIOLookTransformPluginFactory::describeInContext(ImageEffectDescriptor& desc,
     }
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    {
-        BooleanParamDescriptor* param = desc.defineBooleanParam(kParamEnableGPU);
-        param->setLabel(kParamEnableGPULabel);
-        param->setHint(kParamEnableGPUHint);
-        const ImageEffectHostDescription& gHostDescription = *getImageEffectHostDescription();
-        // Resolve advertises OpenGL support in its host description, but never calls render with OpenGL enabled
-        if (gHostDescription.supportsOpenGLRender && (gHostDescription.hostName != "DaVinciResolveLite")) {
-            // OCIO's GPU render is not accurate enough.
-            // see https://github.com/imageworks/OpenColorIO/issues/394
-            param->setDefault(/*true*/ false);
-            if (gHostDescription.APIVersionMajor * 100 + gHostDescription.APIVersionMinor < 104) {
-                // Switching OpenGL render from the plugin was introduced in OFX 1.4
-                param->setEnabled(false);
-            }
-        } else {
-            param->setDefault(false);
-            param->setEnabled(false);
-        }
-
-        if (page) {
-            page->addChild(*param);
-        }
-    }
+    OCIOPluginBase::defineEnableGPUParam(desc, page);
 #endif
 
     ofxsPremultDescribeParams(desc, page);

--- a/OCIO/OCIOLookTransform.cpp
+++ b/OCIO/OCIOLookTransform.cpp
@@ -358,7 +358,7 @@ OCIOLookTransformPlugin::OCIOLookTransformPlugin(OfxImageEffectHandle handle)
     assert(_mix && _maskInvert);
 
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
-    setSupportsOpenGLAndTileInfo(nullptr);
+    setSupportsOpenGLAndTileInfo();
 #endif
 
     bool singleLook = _singleLook->getValue();
@@ -949,7 +949,7 @@ OCIOLookTransformPlugin::changedParam(const InstanceChangedArgs& args,
         _lookCombination->setEvaluateOnChange(!singleLook);
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
     } else if (paramEffectsOpenGLAndTileSupport(paramName) || paramName == kParamPremult) {
-        setSupportsOpenGLAndTileInfo(&args.time);
+        setSupportsOpenGLAndTileInfoAtTime(args.time);
 #endif
     } else {
         _ocio->changedParam(args, paramName);

--- a/OCIO/OCIOLookTransform.cpp
+++ b/OCIO/OCIOLookTransform.cpp
@@ -24,7 +24,7 @@
 
 #ifdef OFX_IO_USING_OCIO
 
-//#include <iostream>
+// #include <iostream>
 #include <memory>
 #ifdef DEBUG
 #include <cstdio> // printf
@@ -39,6 +39,7 @@
 #include <ofxsProcessing.H>
 
 #include "IOUtility.h"
+#include "OCIOPluginBase.h"
 
 using namespace OFX;
 using namespace IO;
@@ -137,7 +138,7 @@ buildLookChoiceMenu(OCIO::ConstConfigRcPtr config,
 }
 
 class OCIOLookTransformPlugin
-    : public ImageEffect {
+    : public OCIOPluginBase {
 public:
     OCIOLookTransformPlugin(OfxImageEffectHandle handle);
 
@@ -340,7 +341,7 @@ private:
 };
 
 OCIOLookTransformPlugin::OCIOLookTransformPlugin(OfxImageEffectHandle handle)
-    : ImageEffect(handle)
+    : OCIOPluginBase(handle)
     , _dstClip(NULL)
     , _srcClip(NULL)
     , _maskClip(NULL)

--- a/OCIO/OCIOPluginBase.cpp
+++ b/OCIO/OCIOPluginBase.cpp
@@ -1,3 +1,22 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * This file is part of openfx-io <https://github.com/NatronGitHub/openfx-io>,
+ * (C) 2018-2023 The Natron Developers
+ * (C) 2013-2018 INRIA
+ *
+ * openfx-io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * openfx-io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with openfx-io.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>
+ * ***** END LICENSE BLOCK ***** */
+
 #include "OCIOPluginBase.h"
 
 #include "IOUtility.h"

--- a/OCIO/OCIOPluginBase.cpp
+++ b/OCIO/OCIOPluginBase.cpp
@@ -1,0 +1,17 @@
+#include "OCIOPluginBase.h"
+
+#include "IOUtility.h"
+#include "ofxsImageEffect.h"
+
+NAMESPACE_OFX_ENTER
+NAMESPACE_OFX_IO_ENTER
+
+OCIOPluginBase::OCIOPluginBase(OfxImageEffectHandle handle)
+    : ImageEffect(handle)
+{
+}
+
+OCIOPluginBase::~OCIOPluginBase() { }
+
+NAMESPACE_OFX_IO_EXIT
+NAMESPACE_OFX_EXIT

--- a/OCIO/OCIOPluginBase.cpp
+++ b/OCIO/OCIOPluginBase.cpp
@@ -13,5 +13,19 @@ OCIOPluginBase::OCIOPluginBase(OfxImageEffectHandle handle)
 
 OCIOPluginBase::~OCIOPluginBase() { }
 
+void
+OCIOPluginBase::setSupportsOpenGLAndTileInfo(BooleanParam* premultParam, BooleanParam* enableGPUParam, const double* const time)
+{
+    const ImageEffectHostDescription& gHostDescription = *getImageEffectHostDescription();
+
+    // GPU rendering is wrong when (un)premult is checked
+    const bool premult = time ? premultParam->getValueAtTime(*time) : premultParam->getValue();
+    const bool enableGPU = time ? enableGPUParam->getValueAtTime(*time) : enableGPUParam->getValue();
+    enableGPUParam->setEnabled(gHostDescription.supportsOpenGLRender && !premult);
+    const bool supportsGL = !premult && enableGPU;
+    setSupportsOpenGLRender(supportsGL);
+    setSupportsTiles(!supportsGL);
+}
+
 NAMESPACE_OFX_IO_EXIT
 NAMESPACE_OFX_EXIT

--- a/OCIO/OCIOPluginBase.cpp
+++ b/OCIO/OCIOPluginBase.cpp
@@ -6,22 +6,76 @@
 NAMESPACE_OFX_ENTER
 NAMESPACE_OFX_IO_ENTER
 
+#if defined(OFX_SUPPORTS_OPENGLRENDER)
+#define kParamEnableGPU "enableGPU"
+#define kParamEnableGPULabel "Enable GPU Render"
+#if OCIO_VERSION_HEX >= 0x02000000
+#define kParamEnableGPUHint_warn ""
+#else
+// OCIO1's GPU render is not accurate enough.
+// see https://github.com/imageworks/OpenColorIO/issues/394
+// and https://github.com/imageworks/OpenColorIO/issues/456
+#define kParamEnableGPUHint_warn "Note that GPU render is not as accurate as CPU render, so this should be enabled with care.\n"
+#endif
+#define kParamEnableGPUHint                                                                                                                                                              \
+    "Enable GPU-based OpenGL render (only available when \"(Un)premult\" is not checked).\n" kParamEnableGPUHint_warn                                                                    \
+    "If the checkbox is checked but is not enabled (i.e. it cannot be unchecked), GPU render can not be enabled or disabled from the plugin and is probably part of the host options.\n" \
+    "If the checkbox is not checked and is not enabled (i.e. it cannot be checked), GPU render is not available on this host."
+#endif
+
 OCIOPluginBase::OCIOPluginBase(OfxImageEffectHandle handle)
     : ImageEffect(handle)
+#if defined(OFX_SUPPORTS_OPENGLRENDER)
+    , _enableGPU(fetchBooleanParam(kParamEnableGPU))
+#endif
 {
+#if defined(OFX_SUPPORTS_OPENGLRENDER)
+    assert(_enableGPU);
+#endif
 }
 
 OCIOPluginBase::~OCIOPluginBase() { }
 
+// static
 void
-OCIOPluginBase::setSupportsOpenGLAndTileInfo(BooleanParam* premultParam, BooleanParam* enableGPUParam, const double* const time)
+OCIOPluginBase::defineEnableGPUParam(ImageEffectDescriptor& desc, PageParamDescriptor* page)
+{
+    BooleanParamDescriptor* param = desc.defineBooleanParam(kParamEnableGPU);
+    param->setLabel(kParamEnableGPULabel);
+    param->setHint(kParamEnableGPUHint);
+    const ImageEffectHostDescription& gHostDescription = *getImageEffectHostDescription();
+    // Resolve advertises OpenGL support in its host description, but never calls render with OpenGL enabled
+    if (gHostDescription.supportsOpenGLRender && (gHostDescription.hostName != "DaVinciResolveLite")) {
+        // OCIO's GPU render is not accurate enough.
+        // see https://github.com/imageworks/OpenColorIO/issues/394
+        param->setDefault(/*true*/ false);
+        if (gHostDescription.APIVersionMajor * 100 + gHostDescription.APIVersionMinor < 104) {
+            // Switching OpenGL render from the plugin was introduced in OFX 1.4
+            param->setEnabled(false);
+        }
+    } else {
+        param->setDefault(false);
+        param->setEnabled(false);
+    }
+
+    if (page) {
+        page->addChild(*param);
+    }
+}
+
+bool OCIOPluginBase::paramEffectsOpenGLAndTileSupport(const std::string& paramName) {
+    return paramName == kParamEnableGPU;
+}
+
+void
+OCIOPluginBase::setSupportsOpenGLAndTileInfo(BooleanParam* premultParam, const double* const time)
 {
     const ImageEffectHostDescription& gHostDescription = *getImageEffectHostDescription();
 
     // GPU rendering is wrong when (un)premult is checked
     const bool premult = time ? premultParam->getValueAtTime(*time) : premultParam->getValue();
-    const bool enableGPU = time ? enableGPUParam->getValueAtTime(*time) : enableGPUParam->getValue();
-    enableGPUParam->setEnabled(gHostDescription.supportsOpenGLRender && !premult);
+    const bool enableGPU = time ? _enableGPU->getValueAtTime(*time) : _enableGPU->getValue();
+    _enableGPU->setEnabled(gHostDescription.supportsOpenGLRender && !premult);
     const bool supportsGL = !premult && enableGPU;
     setSupportsOpenGLRender(supportsGL);
     setSupportsTiles(!supportsGL);

--- a/OCIO/OCIOPluginBase.cpp
+++ b/OCIO/OCIOPluginBase.cpp
@@ -81,14 +81,21 @@ OCIOPluginBase::paramEffectsOpenGLAndTileSupport(const std::string& paramName)
 }
 
 void
-OCIOPluginBase::setSupportsOpenGLAndTileInfo(const double* const time)
+OCIOPluginBase::setSupportsOpenGLAndTileInfo()
 {
-    const ImageEffectHostDescription& gHostDescription = *getImageEffectHostDescription();
+    setSupportsOpenGLAndTileInfo_internal(_premult->getValue(), _enableGPU->getValue());
+}
 
-    // GPU rendering is wrong when (un)premult is checked
-    const bool premult = time ? _premult->getValueAtTime(*time) : _premult->getValue();
-    const bool enableGPU = time ? _enableGPU->getValueAtTime(*time) : _enableGPU->getValue();
-    _enableGPU->setEnabled(gHostDescription.supportsOpenGLRender && !premult);
+void
+OCIOPluginBase::setSupportsOpenGLAndTileInfoAtTime(double time)
+{
+    setSupportsOpenGLAndTileInfo_internal(_premult->getValueAtTime(time), _enableGPU->getValueAtTime(time));
+}
+
+void
+OCIOPluginBase::setSupportsOpenGLAndTileInfo_internal(bool premult, bool enableGPU)
+{
+    _enableGPU->setEnabled(getImageEffectHostDescription()->supportsOpenGLRender && !premult);
     const bool supportsGL = !premult && enableGPU;
     setSupportsOpenGLRender(supportsGL);
     setSupportsTiles(!supportsGL);

--- a/OCIO/OCIOPluginBase.h
+++ b/OCIO/OCIOPluginBase.h
@@ -1,3 +1,22 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * This file is part of openfx-io <https://github.com/NatronGitHub/openfx-io>,
+ * (C) 2018-2023 The Natron Developers
+ * (C) 2013-2018 INRIA
+ *
+ * openfx-io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * openfx-io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with openfx-io.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>
+ * ***** END LICENSE BLOCK ***** */
+
 #ifndef IO_OCIOPluginBase_h
 #define IO_OCIOPluginBase_h
 

--- a/OCIO/OCIOPluginBase.h
+++ b/OCIO/OCIOPluginBase.h
@@ -1,6 +1,8 @@
 #ifndef IO_OCIOPluginBase_h
 #define IO_OCIOPluginBase_h
 
+#include <string>
+
 #include "IOUtility.h"
 #include "ofxsImageEffect.h"
 
@@ -8,17 +10,29 @@ NAMESPACE_OFX_ENTER
 NAMESPACE_OFX_IO_ENTER
 
 class OCIOPluginBase : public ImageEffect {
+public:
+    // Defines enableGPU param in |desc| and adds it as a child of |page|.
+    static void defineEnableGPUParam(ImageEffectDescriptor& desc, PageParamDescriptor* page);
+
 protected:
     OCIOPluginBase(OfxImageEffectHandle handle);
     virtual ~OCIOPluginBase() override;
 
+    // Returns true if |paramName| is the name of a parameter that influences the
+    // value of the SupportsOpenGLRender & SupportsTiles properties.
+    bool paramEffectsOpenGLAndTileSupport(const std::string& paramName);
+
     // Sets SupportsOpenGLRender & SupportsTiles properties based on the current
-    // values of premult and enableGPU parameters.
+    // values of premult and _enableGPU parameters.
     // Note: If |time| is not nullptr, then the parameter values are fetched for the
     // time specified by |*time|.
     void setSupportsOpenGLAndTileInfo(BooleanParam* premultParam,
-                                      BooleanParam* enableGPUParam,
                                       const double* const time);
+
+private:
+#if defined(OFX_SUPPORTS_OPENGLRENDER)
+    BooleanParam* _enableGPU;
+#endif
 };
 
 NAMESPACE_OFX_IO_EXIT

--- a/OCIO/OCIOPluginBase.h
+++ b/OCIO/OCIOPluginBase.h
@@ -1,0 +1,19 @@
+#ifndef IO_OCIOPluginBase_h
+#define IO_OCIOPluginBase_h
+
+#include "IOUtility.h"
+#include "ofxsImageEffect.h"
+
+NAMESPACE_OFX_ENTER
+NAMESPACE_OFX_IO_ENTER
+
+class OCIOPluginBase : public ImageEffect {
+protected:
+    OCIOPluginBase(OfxImageEffectHandle handle);
+    virtual ~OCIOPluginBase() override;
+};
+
+NAMESPACE_OFX_IO_EXIT
+NAMESPACE_OFX_EXIT
+
+#endif // IO_OCIOPluginBase_h

--- a/OCIO/OCIOPluginBase.h
+++ b/OCIO/OCIOPluginBase.h
@@ -11,6 +11,14 @@ class OCIOPluginBase : public ImageEffect {
 protected:
     OCIOPluginBase(OfxImageEffectHandle handle);
     virtual ~OCIOPluginBase() override;
+
+    // Sets SupportsOpenGLRender & SupportsTiles properties based on the current
+    // values of premult and enableGPU parameters.
+    // Note: If |time| is not nullptr, then the parameter values are fetched for the
+    // time specified by |*time|.
+    void setSupportsOpenGLAndTileInfo(BooleanParam* premultParam,
+                                      BooleanParam* enableGPUParam,
+                                      const double* const time);
 };
 
 NAMESPACE_OFX_IO_EXIT

--- a/OCIO/OCIOPluginBase.h
+++ b/OCIO/OCIOPluginBase.h
@@ -18,18 +18,25 @@ protected:
     OCIOPluginBase(OfxImageEffectHandle handle);
     virtual ~OCIOPluginBase() override;
 
+    bool getPremultValueAtTime(double time) { return _premult->getValueAtTime(time); }
+    void getPremultAndPremultChannelAtTime(double time, bool& premult, int& premultChannel);
+
     // Returns true if |paramName| is the name of a parameter that influences the
     // value of the SupportsOpenGLRender & SupportsTiles properties.
     bool paramEffectsOpenGLAndTileSupport(const std::string& paramName);
 
     // Sets SupportsOpenGLRender & SupportsTiles properties based on the current
-    // values of premult and _enableGPU parameters.
+    // values of premult and enableGPU parameters.
     // Note: If |time| is not nullptr, then the parameter values are fetched for the
     // time specified by |*time|.
-    void setSupportsOpenGLAndTileInfo(BooleanParam* premultParam,
-                                      const double* const time);
+    void setSupportsOpenGLAndTileInfo(const double* const time);
+
+    void changedSrcClip(Clip* srcClip);
 
 private:
+    BooleanParam* _premult;
+    ChoiceParam* _premultChannel;
+
 #if defined(OFX_SUPPORTS_OPENGLRENDER)
     BooleanParam* _enableGPU;
 #endif

--- a/OCIO/OCIOPluginBase.h
+++ b/OCIO/OCIOPluginBase.h
@@ -1,6 +1,7 @@
 #ifndef IO_OCIOPluginBase_h
 #define IO_OCIOPluginBase_h
 
+#include <optional>
 #include <string>
 
 #include "IOUtility.h"
@@ -25,15 +26,16 @@ protected:
     // value of the SupportsOpenGLRender & SupportsTiles properties.
     bool paramEffectsOpenGLAndTileSupport(const std::string& paramName);
 
-    // Sets SupportsOpenGLRender & SupportsTiles properties based on the current
+    // Sets SupportsOpenGLRender & SupportsTiles properties based on the
     // values of premult and enableGPU parameters.
-    // Note: If |time| is not nullptr, then the parameter values are fetched for the
-    // time specified by |*time|.
-    void setSupportsOpenGLAndTileInfo(const double* const time);
+    void setSupportsOpenGLAndTileInfo();
+    void setSupportsOpenGLAndTileInfoAtTime(double time);
 
     void changedSrcClip(Clip* srcClip);
 
 private:
+    void setSupportsOpenGLAndTileInfo_internal(bool premult, bool enableGPU);
+
     BooleanParam* _premult;
     ChoiceParam* _premultChannel;
 


### PR DESCRIPTION
This change makes the setting of the SupportsOpenGL and SupportsTiles consistent between plugin creation and parameter changes. It also establishes a base class for code that is common across all of the OCIO plugins. For now I've only moved the code that directly effects the OpenGL and Tiles logic, but I believe more cleanup could likely be done.

I incremented the minor version of these plugins because this does introduce a tiny change in behavior because the construction path and parameter change paths were slightly different.