### PR TITLE
Fix assert in OCIODisplay plugin when premult param is set.

### DIFF
--- a/OCIO/OCIOCDLTransform.cpp
+++ b/OCIO/OCIOCDLTransform.cpp
@@ -198,39 +198,6 @@ private:
                        double time,
                        const OfxRectI& renderWindow,
                        const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       Image* dstImg)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
-        void* dstPixelData;
-        OfxRectI dstBounds;
-        PixelComponentEnum dstPixelComponents;
-        BitDepthEnum dstBitDepth;
-        int dstRowBytes;
-        getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
-        int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      maskmix,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
-
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       bool maskmix,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
                        const void* srcPixelData,
                        const OfxRectI& srcBounds,
                        PixelComponentEnum srcPixelComponents,
@@ -247,37 +214,6 @@ private:
 
         getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
         int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      maskmix,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
-
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       bool maskmix,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       void* dstPixelData,
-                       const OfxRectI& dstBounds,
-                       PixelComponentEnum dstPixelComponents,
-                       int dstPixelComponentCount,
-                       BitDepthEnum dstBitDepth,
-                       int dstRowBytes)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
         copyPixelData(unpremult,
                       premult,
                       maskmix,

--- a/OCIO/OCIOColorSpace.cpp
+++ b/OCIO/OCIOColorSpace.cpp
@@ -114,42 +114,6 @@ private:
     void renderGPU(const RenderArguments& args);
 #endif
 
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       int premultChannel,
-                       bool maskmix,
-                       double mix,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       Image* dstImg)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
-        void* dstPixelData;
-        OfxRectI dstBounds;
-        PixelComponentEnum dstPixelComponents;
-        BitDepthEnum dstBitDepth;
-        int dstRowBytes;
-        getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
-        int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      premultChannel,
-                      maskmix,
-                      mix,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
 
     void copyPixelData(bool unpremult,
                        bool premult,
@@ -175,41 +139,6 @@ private:
 
         getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
         int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      premultChannel,
-                      maskmix,
-                      mix,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
-
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       int premultChannel,
-                       bool maskmix,
-                       double mix,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       void* dstPixelData,
-                       const OfxRectI& dstBounds,
-                       PixelComponentEnum dstPixelComponents,
-                       int dstPixelComponentCount,
-                       BitDepthEnum dstBitDepth,
-                       int dstRowBytes)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
         copyPixelData(unpremult,
                       premult,
                       premultChannel,

--- a/OCIO/OCIODisplay.cpp
+++ b/OCIO/OCIODisplay.cpp
@@ -54,7 +54,7 @@ OFXS_NAMESPACE_ANONYMOUS_ENTER
 #define kPluginDescription "Uses the OpenColorIO library to apply a colorspace conversion to an image sequence, so that it can be accurately represented on a specific display device."
 #define kPluginIdentifier "fr.inria.openfx.OCIODisplay"
 #define kPluginVersionMajor 1 // Incrementing this number means that you have broken backwards compatibility of the plug-in.
-#define kPluginVersionMinor 0 // Increment this when you have fixed a bug or made it faster.
+#define kPluginVersionMinor 1 // Increment this when you have fixed a bug or made it faster.
 
 #define kSupportsTiles 1
 #define kSupportsMultiResolution 1
@@ -222,39 +222,6 @@ private:
                        double time,
                        const OfxRectI& renderWindow,
                        const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       Image* dstImg)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
-        void* dstPixelData;
-        OfxRectI dstBounds;
-        PixelComponentEnum dstPixelComponents;
-        BitDepthEnum dstBitDepth;
-        int dstRowBytes;
-        getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
-        int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      premultChannel,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
-
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       int premultChannel,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
                        const void* srcPixelData,
                        const OfxRectI& srcBounds,
                        PixelComponentEnum srcPixelComponents,
@@ -271,37 +238,6 @@ private:
 
         getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
         int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      premultChannel,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
-
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       int premultChannel,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       void* dstPixelData,
-                       const OfxRectI& dstBounds,
-                       PixelComponentEnum dstPixelComponents,
-                       int dstPixelComponentCount,
-                       BitDepthEnum dstBitDepth,
-                       int dstRowBytes)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
         copyPixelData(unpremult,
                       premult,
                       premultChannel,
@@ -628,9 +564,26 @@ OCIODisplayPlugin::copyPixelData(bool unpremult,
                          dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
         } // switch
     } else {
-        // not handled: (should never happen in OCIODisplay)
         // !unpremult && premult
-        assert(false); // should never happen
+        if (dstPixelComponents == ePixelComponentRGBA) {
+            PixelCopierPremult<float, 4, 1, float, 4, 1> fred(*this);
+            fred.setPremultMaskMix(true, premultChannel, 1.);
+            setupAndCopy(fred, time, renderWindow, renderScale,
+                         srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
+                         dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
+        } else if (dstPixelComponents == ePixelComponentRGB) {
+            PixelCopierPremult<float, 3, 1, float, 3, 1> fred(*this);
+            fred.setPremultMaskMix(true, premultChannel, 1.);
+            setupAndCopy(fred, time, renderWindow, renderScale,
+                         srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
+                         dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
+        } else if (dstPixelComponents == ePixelComponentAlpha) {
+            PixelCopierPremult<float, 1, 1, float, 1, 1> fred(*this);
+            fred.setPremultMaskMix(true, premultChannel, 1.);
+            setupAndCopy(fred, time, renderWindow, renderScale,
+                         srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
+                         dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
+        } // switch
     }
 }
 

--- a/OCIO/OCIOFileTransform.cpp
+++ b/OCIO/OCIOFileTransform.cpp
@@ -171,39 +171,6 @@ private:
                        double time,
                        const OfxRectI& renderWindow,
                        const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       Image* dstImg)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
-        void* dstPixelData;
-        OfxRectI dstBounds;
-        PixelComponentEnum dstPixelComponents;
-        BitDepthEnum dstBitDepth;
-        int dstRowBytes;
-        getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
-        int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      maskmix,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
-
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       bool maskmix,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
                        const void* srcPixelData,
                        const OfxRectI& srcBounds,
                        PixelComponentEnum srcPixelComponents,
@@ -220,37 +187,6 @@ private:
 
         getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
         int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      maskmix,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
-
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       bool maskmix,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       void* dstPixelData,
-                       const OfxRectI& dstBounds,
-                       PixelComponentEnum dstPixelComponents,
-                       int dstPixelComponentCount,
-                       BitDepthEnum dstBitDepth,
-                       int dstRowBytes)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
         copyPixelData(unpremult,
                       premult,
                       maskmix,

--- a/OCIO/OCIOLogConvert.cpp
+++ b/OCIO/OCIOLogConvert.cpp
@@ -130,39 +130,6 @@ private:
                        double time,
                        const OfxRectI& renderWindow,
                        const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       Image* dstImg)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
-        void* dstPixelData;
-        OfxRectI dstBounds;
-        PixelComponentEnum dstPixelComponents;
-        BitDepthEnum dstBitDepth;
-        int dstRowBytes;
-        getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
-        int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      maskmix,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
-
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       bool maskmix,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
                        const void* srcPixelData,
                        const OfxRectI& srcBounds,
                        PixelComponentEnum srcPixelComponents,
@@ -179,37 +146,6 @@ private:
 
         getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
         int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      maskmix,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
-
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       bool maskmix,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       void* dstPixelData,
-                       const OfxRectI& dstBounds,
-                       PixelComponentEnum dstPixelComponents,
-                       int dstPixelComponentCount,
-                       BitDepthEnum dstBitDepth,
-                       int dstRowBytes)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
         copyPixelData(unpremult,
                       premult,
                       maskmix,

--- a/OCIO/OCIOLookTransform.cpp
+++ b/OCIO/OCIOLookTransform.cpp
@@ -182,39 +182,6 @@ private:
                        double time,
                        const OfxRectI& renderWindow,
                        const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       Image* dstImg)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
-        void* dstPixelData;
-        OfxRectI dstBounds;
-        PixelComponentEnum dstPixelComponents;
-        BitDepthEnum dstBitDepth;
-        int dstRowBytes;
-        getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
-        int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      maskmix,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
-
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       bool maskmix,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
                        const void* srcPixelData,
                        const OfxRectI& srcBounds,
                        PixelComponentEnum srcPixelComponents,
@@ -231,37 +198,6 @@ private:
 
         getImageData(dstImg, &dstPixelData, &dstBounds, &dstPixelComponents, &dstBitDepth, &dstRowBytes);
         int dstPixelComponentCount = dstImg->getPixelComponentCount();
-        copyPixelData(unpremult,
-                      premult,
-                      maskmix,
-                      time,
-                      renderWindow, renderScale,
-                      srcPixelData, srcBounds, srcPixelComponents, srcPixelComponentCount, srcBitDepth, srcRowBytes,
-                      dstPixelData, dstBounds, dstPixelComponents, dstPixelComponentCount, dstBitDepth, dstRowBytes);
-    }
-
-    void copyPixelData(bool unpremult,
-                       bool premult,
-                       bool maskmix,
-                       double time,
-                       const OfxRectI& renderWindow,
-                       const OfxPointD& renderScale,
-                       const Image* srcImg,
-                       void* dstPixelData,
-                       const OfxRectI& dstBounds,
-                       PixelComponentEnum dstPixelComponents,
-                       int dstPixelComponentCount,
-                       BitDepthEnum dstBitDepth,
-                       int dstRowBytes)
-    {
-        const void* srcPixelData;
-        OfxRectI srcBounds;
-        PixelComponentEnum srcPixelComponents;
-        BitDepthEnum srcBitDepth;
-        int srcRowBytes;
-
-        getImageData(srcImg, &srcPixelData, &srcBounds, &srcPixelComponents, &srcBitDepth, &srcRowBytes);
-        int srcPixelComponentCount = srcImg->getPixelComponentCount();
         copyPixelData(unpremult,
                       premult,
                       maskmix,


### PR DESCRIPTION
This fixes an assert in the OCIODisplay plugin when the premult param is set. The comment above the assert in copyPixelData() indicates that !unpremult && premult should never happen, but a call to this function in OCIODisplayPlugin::render() does allow this to happen when the premult param is set. I've added the necessary code to handle this situation. I verified the behavior by creating a node graph that compares the output of an OCIODisplay node with premult unchecked against the output of a Premult -> OCIODisplay(w/ premult checked)->Unpremult set of nodes.

I also discovered that there were several unused copyPixelData() methods in the OCIODisplay and the other OCIO plugins so I've removed them.