### PR TITLE
Add OCIOPluginBase.o to IO/Makefile to fix IO.ofx build buster.

### DIFF
--- a/IO/Makefile
+++ b/IO/Makefile
@@ -28,6 +28,7 @@ OCIOCDLTransform.o \
 OCIOFileTransform.o \
 OCIOLogConvert.o \
 OCIOLookTransform.o \
+OCIOPluginBase.o \
 
 OCIO_OPENGL_OBJS = GenericOCIOOpenGL.o glsl.o glad.o ofxsOGLUtilities.o
 


### PR DESCRIPTION
Fix a build buster accidentally introduced by #28 .