### PR TITLE
WriteOIIO: now part of EXR zip compression level

### DIFF
--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -832,8 +832,7 @@ WriteOIIOPlugin::refreshParamsVisibility(const string& filename)
             int compression_i;
             _compression->getValue(compression_i);
             EParamCompression compression = (EParamCompression)compression_i;
-            hasQuality = (compression == eParamCompressionJPEG ||
-                          compression == eParamCompressionZip);
+            hasQuality = (compression == eParamCompressionJPEG);
             if (isEXR) {
                 hasDWA = (compression == eParamCompressionDWAa) || (compression == eParamCompressionDWAb);
                 hasZIP = (compression == eParamCompressionZip) || (compression == eParamCompressionZips);

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -1140,6 +1140,7 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
         compression += ':' + std::to_string(zipCompressionLevel); // zip and zips compression level 1 to 9 range
 #else
         spec.attribute("CompressionQuality", zipCompressionLevel);
+        spec.attribute("tiff:zipquality", zipCompressionLevel);
 #endif
     }
     spec.attribute("Orientation", orientation + 1);

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -125,6 +125,12 @@ enum ETuttlePluginComponents {
     "Amount of compression when using Dreamworks DWAA or DWAB compression options. These lossy formats are variable in quality and can minimize the compression artifacts. Higher values will result in greater compression and likewise smaller file size, but increases the chance for artifacts. Values from 45 to 150 are usually correct for production shots, whereas HDR vacation photos could use up to 500. Values below 45 should give no visible imprrovement on photographs. [EXR w/ DWAa or DWAb comp.]"
 #define kParamOutputDWACompressionLevelDefault 45
 
+#define kParamOutputZIPCompressionLevel "zipCompressionLevel"
+#define kParamOutputZIPCompressionLevelLabel "ZIP Compression Level"
+#define kParamOutputZIPCompressionLevelHint \
+    "Amount of compression when using Dreamworks Zip or Zips compression options. These Lossless formats are variable in level and can minimize the compression artifacts. Higher values will result in greater compression and likewise smaller file size, but increases the chance for artifacts. [EXR w/ Zip or Zips comp.]"
+#define kParamOutputZIPCompressionLevelDefault 4
+
 #define kParamOutputOrientation "orientation"
 #define kParamOutputOrientationLabel "Orientation"
 #define kParamOutputOrientationHint                                                     \

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -1655,7 +1655,7 @@ WriteOIIOPluginFactory::describeInContext(ImageEffectDescriptor& desc,
         }
     }
     {
-        IntParamDescriptor* param = desc.defineDoubleParam(kParamOutputZIPCompressionLevel);
+        IntParamDescriptor* param = desc.defineIntParam(kParamOutputZIPCompressionLevel);
         param->setLabel(kParamOutputZIPCompressionLevelLabel);
         param->setHint(kParamOutputZIPCompressionLevelHint);
         param->setRange(1, 9);

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -371,6 +371,7 @@ private:
     ChoiceParam* _bitDepth;
     IntParam* _quality;
     DoubleParam* _dwaCompressionLevel;
+    IntParam* _zipCompressionLevel;
     ChoiceParam* _orientation;
     ChoiceParam* _compression;
     ChoiceParam* _tileSize;
@@ -387,6 +388,7 @@ WriteOIIOPlugin::WriteOIIOPlugin(OfxImageEffectHandle handle,
     , _bitDepth(NULL)
     , _quality(NULL)
     , _dwaCompressionLevel(NULL)
+    , _zipCompressionLevel(NULL)
     , _orientation(NULL)
     , _compression(NULL)
     , _tileSize(NULL)
@@ -400,6 +402,7 @@ WriteOIIOPlugin::WriteOIIOPlugin(OfxImageEffectHandle handle,
     _bitDepth = fetchChoiceParam(kParamBitDepth);
     _quality = fetchIntParam(kParamOutputQuality);
     _dwaCompressionLevel = fetchDoubleParam(kParamOutputDWACompressionLevel);
+    _zipCompressionLevel = fetchIntParam(kParamOutputZIPCompressionLevel);
     _orientation = fetchChoiceParam(kParamOutputOrientation);
     _compression = fetchChoiceParam(kParamOutputCompression);
     _tileSize = fetchChoiceParam(kParamTileSize);

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -833,9 +833,10 @@ WriteOIIOPlugin::refreshParamsVisibility(const string& filename)
             _compression->getValue(compression_i);
             EParamCompression compression = (EParamCompression)compression_i;
             hasQuality = (compression == eParamCompressionJPEG);
+            hasZIP = (compression == eParamCompressionZip);
             if (isEXR) {
                 hasDWA = (compression == eParamCompressionDWAa) || (compression == eParamCompressionDWAb);
-                hasZIP = (compression == eParamCompressionZip) || (compression == eParamCompressionZips);
+                hasZIP |= (compression == eParamCompressionZips);
             }
         }
         _dwaCompressionLevel->setIsSecretAndDisabled(!hasDWA);
@@ -1128,17 +1129,17 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
 #else
         spec.attribute("CompressionQuality", quality);
 #endif
-    }
-    if (!_dwaCompressionLevel->getIsSecret()) {
+    } else if (!_dwaCompressionLevel->getIsSecret()) {
 #if OIIO_VERSION >= 20100 // Introduced in OIIO 2.1.0 https://github.com/OpenImageIO/oiio/pull/2111
         compression += ':' + std::to_string((int)dwaCompressionLevel);
 #else
         spec.attribute("openexr:dwaCompressionLevel", (float)dwaCompressionLevel);
 #endif
-    }
-    if (!_zipCompressionLevel->getIsSecret()) {
+    } else if (!_zipCompressionLevel->getIsSecret()) {
 #if OIIO_VERSION >= 20100 // Introduced in OIIO 2.1.0 https://github.com/OpenImageIO/oiio/pull/2111
-        compression += ':' + std::to_string((int)zipCompressionLevel); // zip and zips compression level 1 to 9 range
+        compression += ':' + std::to_string(zipCompressionLevel); // zip and zips compression level 1 to 9 range
+#else
+        spec.attribute("CompressionQuality", zipCompressionLevel);
 #endif
     }
     spec.attribute("Orientation", orientation + 1);

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -997,6 +997,10 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
     if (!_dwaCompressionLevel->getIsSecret()) {
         _dwaCompressionLevel->getValue(dwaCompressionLevel);
     }
+    int zipCompressionLevel = 4;
+    if (!_zipCompressionLevel->getIsSecret()) {
+        _zipCompressionLevel->getValue(zipCompressionLevel);
+    }
     int orientation;
     _orientation->getValue(orientation);
     int compression_i;
@@ -1640,6 +1644,17 @@ WriteOIIOPluginFactory::describeInContext(ImageEffectDescriptor& desc,
         param->setRange(0, DBL_MAX);
         param->setDisplayRange(45, 200);
         param->setDefault(kParamOutputDWACompressionLevelDefault);
+        if (page) {
+            page->addChild(*param);
+        }
+    }
+    {
+        IntParamDescriptor* param = desc.defineDoubleParam(kParamOutputZIPCompressionLevel);
+        param->setLabel(kParamOutputZIPCompressionLevelLabel);
+        param->setHint(kParamOutputZIPCompressionLevelHint);
+        param->setRange(1, 9);
+        param->setDisplayRange(1, 9);
+        param->setDefault(kParamOutputZIPCompressionLevelDefault);
         if (page) {
             page->addChild(*param);
         }


### PR DESCRIPTION
ZIP compression level 1 to 9 range [here](https://openimageio.readthedocs.io/en/master/builtinplugins.html#openexr).

`zip` and `zips` compression.

@acolwell @rodlie @devernay @YakoYakoYokuYoku 