### PR TITLE
OCIOLookTransforms: prepend process_space to the look names

### DIFF
--- a/OCIO/OCIOLookTransform.cpp
+++ b/OCIO/OCIOLookTransform.cpp
@@ -116,7 +116,20 @@ buildLookChoiceMenu(OCIO::ConstConfigRcPtr config,
         return;
     }
     for (int i = 0; i < config->getNumLooks(); ++i) {
-        choice->appendOption(config->getLookNameByIndex(i));
+        const char *lookName = config->getLookNameByIndex(i);
+        auto look = config->getLook(lookName);
+        auto lookProcessSpace = std::string(look->getProcessSpace());
+        auto optionName = std::string(lookName);
+        // Add look process space to the option name if it is not linear.
+        // Pre-2.6.0 OCIO config had "Filmic - " prefix for filmic process space.
+        if ((lookProcessSpace != "linear") && (lookProcessSpace.rfind("Filmic - ", 0) != 0)) {
+            if (lookProcessSpace == "Filmic Log") {
+                // To be compatible with pre-2.6.0 configs
+                lookProcessSpace = "Filmic";
+            }
+            optionName = lookProcessSpace + " - " + optionName;
+        }
+        choice->appendOption(optionName);
     }
 }
 


### PR DESCRIPTION
But be compatible with the pre-2.6.0 OCIO config, which had "Filmic - " baked into the look name.
A PR exists on OpenColorIO-COnfigs with an updated OCIO2 blender config: https://github.com/NatronGitHub/OpenColorIO-Configs/pull/1