### PR TITLE
add support lineorder OpenEXR

### DIFF
--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -1032,7 +1032,7 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
     string compression;
     int lineorder_i;
     _lineorder->getValue(lineorder_i);
-    string openexr:lineOrder;
+    string lineOrder;
 
     switch ((EParamCompression)compression_i) {
     case eParamCompressionAuto:
@@ -1083,13 +1083,13 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
 
     switch ((EParamLineOrder)lineorder_i) {
     case eParamLineOrderIncreasingY: // EXR
-        openexr:lineOrder = "increasingY";
+        lineOrder = "increasingY";
         break;
     case eParamLineOrderRandomY: // EXR
-        openexr:lineOrder = "randomY";
+        lineOrder = "randomY";
         break;
     case eParamLineOrderDecreasingY: // EXR
-        openexr:lineOrder = "decreasingY";
+        lineOrder = "decreasingY";
         break;
     }
     
@@ -1761,11 +1761,11 @@ WriteOIIOPluginFactory::describeInContext(ImageEffectDescriptor& desc,
         param->setLabel(kParamOutputLineOrderLabel);
         param->setHint(kParamOutputLineOrderHint);
         assert(param->getNOptions() == eParamLineOrderIncreasingY);
-        param->appendOption(kParamOutputLineOrderOptionIncreasingY);
+        param->appendOption(kParamLineOrderOptionIncreasingY);
         assert(param->getNOptions() == eParamLineOrderRandomY);
-        param->appendOption(kParamOutputLineOrderOptionRandomY);
+        param->appendOption(kParamLineOrderOptionRandomY);
         assert(param->getNOptions() == eParamLineOrderDecreasingY);
-        param->appendOption(kParamOutputLineOrderOptionDecreasingY);
+        param->appendOption(kParamLineOrderOptionDecreasingY);
         param->setDefault(0);
         if (page) {
             page->addChild(*param);

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -212,7 +212,7 @@ enum EParamCompression {
     eParamCompressionPACKBITS
 };
 
-#define kParamOutputLineOrder "openexr:lineOrder"
+#define kParamOutputLineOrder "lineorder"
 #define kParamOutputLineOrderLabel "Line Order"
 #define kParamOutputLineOrderHint "Specifies in what order the scan lines in the file are stored in the file. [EXR]"
 
@@ -1032,7 +1032,7 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
     string compression;
     int lineorder_i;
     _lineorder->getValue(lineorder_i);
-    string lineOrder;
+    string lineorder;
 
     switch ((EParamCompression)compression_i) {
     case eParamCompressionAuto:
@@ -1083,13 +1083,13 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
 
     switch ((EParamLineOrder)lineorder_i) {
     case eParamLineOrderIncreasingY: // EXR
-        lineOrder = "increasingY";
+        lineorder = "increasingY";
         break;
     case eParamLineOrderRandomY: // EXR
-        lineOrder = "randomY";
+        lineorder = "randomY";
         break;
     case eParamLineOrderDecreasingY: // EXR
-        lineOrder = "decreasingY";
+        lineorder = "decreasingY";
         break;
     }
     


### PR DESCRIPTION
add support `openexr:lineOrder` [here](https://openimageio.readthedocs.io/en/v2.4.15.0/builtinplugins.html#openexr).

OpenEXR lineOrder attribute `increasingY`, `randomY`, or `decreasingY`.