### PR TITLE
Allow manual CI action runs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Continous Integration tests
 
 on:
+  workflow_dispatch: {}
   push:
     paths-ignore:
       - LICENSE


### PR DESCRIPTION
This allows the CI workflow to be manually run from GitHub Actions tab. This is helpful for regenerating testing binaries when the Windows pacman repo gets updated.