### PR TITLE
add lineOrder randomY

### DIFF
--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -129,6 +129,9 @@ enum ETuttlePluginComponents {
     "Compression level for zip/deflate compression, on a scale from 1 (fastest, minimal compression) to 9 (slowest, maximal compression) [EXR, TIFF or Zfile w/ zip or zips comp.]"
 #define kParamOutputZIPCompressionLevelDefault 4
 
+#define kParamOutputLineOrderOptionRandomY "randomY", "only for tiled files; tiles are written in random order", "randomY"
+    eParamLineOrderRandomY
+
 #define kParamOutputOrientation "orientation"
 #define kParamOutputOrientationLabel "Orientation"
 #define kParamOutputOrientationHint                                                     \
@@ -1061,6 +1064,10 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
         break;
     }
 
+    case eParamLineOrderRandomY:
+        lineOrder = "randomY";
+        break;
+    
     spec.attribute("oiio:BitsPerSample", bitsPerSample);
     // oiio:UnassociatedAlpha should be set if the data buffer is unassociated/unpremultiplied.
     // However, WriteOIIO::getExpectedInputPremultiplication() stated that input to the encode()
@@ -1725,6 +1732,9 @@ WriteOIIOPluginFactory::describeInContext(ImageEffectDescriptor& desc,
         }
     }
 
+        assert(param->getNOptions() == eParamLineOrderRandomY);
+        param->appendOption(kParamOutputLineOrderOptionRandomY);
+    
     if (gIsMultiplanarV2) {
 
         MultiPlane::Factory::describeInContextAddPlaneChoice(desc, page, kParamOutputChannels, kParamOutputChannelsLabel, kParamOutputChannelsHint);


### PR DESCRIPTION
image before setting lineOrder to randomY. [here](https://openimageio.readthedocs.io/en/v2.5.9.0/builtinplugins.html#openexr).

- `textureformat` MIP-mapped OpenEXR files
- `openexr:roundingmode` the MIPmap rounding mode of the file.

```
    // We must setTileDescription here before the put_parameter calls below,
    // since put_parameter will check the header to ensure this is a tiled
    // image before setting lineOrder to randomY.
    if (spec.tile_width)
        header.setTileDescription(
            Imf::TileDescription(spec.tile_width, spec.tile_height,
                                 Imf::LevelMode(m_levelmode),
                                 Imf::LevelRoundingMode(m_roundingmode)));
```