### PR TITLE
add Write Texture Format

### DIFF
--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -1187,6 +1187,7 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
 #endif
     }
     spec.attribute("Orientation", orientation + 1);
+    spec.attribute("textureformat", textureformat);
     if (!compression.empty()) { // some formats have a good value for the default compression
         spec.attribute("compression", compression);
     }

--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -247,6 +247,7 @@ enum EParamTextureformat {
     eParamTextureformatShadow
 }
 
+
 #define kParamProcessAllLayers "processAllLayers"
 #define kParamProcessAllLayersLabel "All Layers"
 #define kParamProcessAllLayersHint "When checked, all layers will be written to the file"


### PR DESCRIPTION
Texture Format:
`Plain Texture` for MIP-mapped OpenEXR files.
`CubeFace Environment` for environment maps.
`Latlong Environment` for environment maps.
`Shadow` for One level.
![Untitled18](https://github.com/NatronGitHub/openfx-io/assets/156521906/4e73772d-eee3-467b-8978-f6b3187d6bc3)

@devernay @YakoYakoYokuYoku @rodlie @acolwell you please review before I merge?

I only basic testing
