### PR TITLE
Fix compression quality for image file formats like jpeg.

### DIFF
--- a/OIIO/WriteOIIO.cpp
+++ b/OIIO/WriteOIIO.cpp
@@ -1015,8 +1015,16 @@ WriteOIIOPlugin::beginEncodeParts(void* user_data,
     string compression;
 
     switch ((EParamCompression)compression_i) {
-    case eParamCompressionAuto:
-        break;
+    case eParamCompressionAuto: {
+        // Set compression string for formats that only have a single compression type.
+        static const char* formats[] = {"jpeg", "webp", "heic", "avif", nullptr};
+        for (int i = 0; formats[i] != nullptr; ++i) {
+            if (strcmp(data->output->format_name(), formats[i]) == 0) {
+                compression = formats[i];
+                break;
+            }
+        }
+    } break;
     case eParamCompressionNone: // EXR, TIFF, IFF
         compression = "none";
         break;


### PR DESCRIPTION
This fixes an issue introduced by https://github.com/NatronGitHub/openfx-io/pull/31 that causes the compression quality to be ignored for formats with default compression like JPEG files. In the case of these files, the compression string was not being set and so the line that was appending the quality was actually triggering behavior that caused the quality value to be ignored. This in turn started causing the Natron-Tests to start failing because the JPEG writer, used in these tests, was not honoring the requested quality value.

The fix here simply specifies a valid base compression string for these formats so that when the quality is appended, the compression/codec part of the string is not empty. This avoids triggering logic in OIIO that ignores the quality values for empty compression/codec strings.